### PR TITLE
Truncate long abstracts in search results

### DIFF
--- a/src/kerko/templates/kerko/_search-result.html.jinja2
+++ b/src/kerko/templates/kerko/_search-result.html.jinja2
@@ -48,6 +48,6 @@
         {%- endblock search_item_display %}
     {%- endif -%}
     {%- if show_abstracts and result.data['abstractNote']|trim|length %}
-        <p class="search-abstract pre-line">{{ result.data['abstractNote']|escape|urlize(target='_blank')|trim }}</p>
+        <p class="search-abstract pre-line">{{ result.data['abstractNote']|truncate(500)|escape|urlize(target='_blank')|trim }}</p>
     {%- endif %}
 </li>


### PR DESCRIPTION
- [x] Added truncate of 500 to limit abstract words that show on the search result to be 500 words