### PR TITLE
Have multiple biblografical reference citation Styles

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,6 @@ install_requires =
     Whoosh >=2.7.4
     wrapt >=1.10.0
     WTForms >=3.0.0
-    citeproc-py >=0.6.0
 include_package_data = True
 setup_requires =
     Babel >=2.6.0  # For compiling catalog.

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     Whoosh >=2.7.4
     wrapt >=1.10.0
     WTForms >=3.0.0
+    citeproc-py >=0.6.0
 include_package_data = True
 setup_requires =
     Babel >=2.6.0  # For compiling catalog.

--- a/src/kerko/composer.py
+++ b/src/kerko/composer.py
@@ -322,13 +322,13 @@ class Composer:
             )
         )
         # Formatted citation.
-        # self.add_field(
-        #    FieldSpec(
-        #        key='bib',
-        #        field_type=STORED,
-        #        extractor=extractors.ItemExtractor(key='bib', format_='bib'),
-        #    )
-        # )
+        self.add_field(
+           FieldSpec(
+               key='bib',
+               field_type=STORED,
+               extractor=extractors.ItemExtractor(key='bib', format_='bib'),
+           )
+        )
         # Custom citation using csl(to be built)
         for style in config_get(config, 'kerko.zotero.csl_style'):
             self.add_field(
@@ -342,14 +342,6 @@ class Composer:
                     )
                 ),
             )
-
-        self.add_field(
-            FieldSpec(
-                key='cite',
-                field_type=STORED,
-                extractor=extractors.ItemExtractor(key='bib', format_='bib'),
-            )
-        )
         # OpenURL Coins.
         self.add_field(
             FieldSpec(

--- a/src/kerko/composer.py
+++ b/src/kerko/composer.py
@@ -27,7 +27,7 @@ class Composer:
 
     The schema is the representation of documents and their fields in the search
     index. It is meant to be fully constructed at app configuration time and not
-    changed afterwards. If schema elements need to be modified or removed, the
+    changed afterward. If schema elements need to be modified or removed, the
     application should be stopped, and the search index cleaned and rebuilt.
     """
 
@@ -36,7 +36,7 @@ class Composer:
         Instantiate search elements based on config settings.
 
         This initializes elements based on config settings, but other "manually"
-        instantiated elements may still be added afterwards, using the `add_*()`
+        instantiated elements may still be added afterward, using the `add_*()`
         methods.
         """
 
@@ -113,16 +113,11 @@ class Composer:
         scopes_dict = config_get(config, 'kerko.scopes')
         for scope_key, scope_config in scopes_dict.items():
             if scope_config['enabled']:
-                kwargs = {
-                    'weight': scope_config['weight'],
-                }
-                kwargs['selector_label'] = (
-                    scope_config.get('selector_label') or selector_label.get(scope_key, scope_key)
-                )
-                kwargs['breadbox_label'] = (
-                    scope_config.get('breadbox_label') or breadbox_label.get(scope_key, scope_key)
-                )
-                kwargs['help_text'] = scope_config.get('help_text') or help_text.get(scope_key, '')
+                kwargs = {'weight': scope_config['weight'], 'selector_label': (
+                        scope_config.get('selector_label') or selector_label.get(scope_key, scope_key)
+                ), 'breadbox_label': (
+                        scope_config.get('breadbox_label') or breadbox_label.get(scope_key, scope_key)
+                ), 'help_text': scope_config.get('help_text') or help_text.get(scope_key, '')}
                 self.add_scope(ScopeSpec(key=scope_key, **kwargs))
 
     def init_fields(self, config: Config) -> None:
@@ -327,27 +322,23 @@ class Composer:
             )
         )
         # Formatted citation.
-        #self.add_field(
+        # self.add_field(
         #    FieldSpec(
         #        key='bib',
         #        field_type=STORED,
         #        extractor=extractors.ItemExtractor(key='bib', format_='bib'),
         #    )
-        #)
-        #Custom citation using csl(to be built)
-        for style in config_get(config,'kerko.zotero.csl_style'):
+        # )
+        # Custom citation using csl(to be built)
+        for style in config_get(config, 'kerko.zotero.csl_style'):
             self.add_field(
                 FieldSpec(
-                    key='cite_'+style,
+                    key='cite_' + style,
                     field_type=STORED,
-                    extractor=extractors.ChainExtractor(
-                        extractors=[
-                            extractors.ConvertCitationExtractor(targetFormat=style),
-                            extractors.ItemExtractor(key='bib', format_='bib'),
-                    ]
+                    extractor=extractors.ConvertCitationExtractor(targetFormat=style)
                 ),
             )
-        )
+
         self.add_field(
             FieldSpec(
                 key='cite',
@@ -784,7 +775,8 @@ class Composer:
                             key=format_key,
                             field=self.fields['ris'],
                             label=format_config.get('label') or _("RIS"),
-                            help_text=format_config.get('help_text') or _("Recommended format for most reference management software"),
+                            help_text=format_config.get('help_text') or _(
+                                "Recommended format for most reference management software"),
                             **kwargs,
                         )
                     )
@@ -794,7 +786,8 @@ class Composer:
                             key=format_key,
                             field=self.fields['bibtex'],
                             label=format_config.get('label') or _("BibTeX"),
-                            help_text=format_config.get('help_text') or _("Recommended format for BibTeX-specific software"),
+                            help_text=format_config.get('help_text') or _(
+                                "Recommended format for BibTeX-specific software"),
                             **kwargs,
                         )
                     )
@@ -819,7 +812,7 @@ class Composer:
                             reverse=True,
                             reverse_key='isCitedBy',
                             reverse_field_key='rev_cites',
-                            reverse_label=_("Cited by"),
+                            reverse_label="Cited by",
                         )
                     )
                 elif rel_key == 'related':
@@ -905,7 +898,7 @@ class Composer:
         """
         Return a list of specifications, sorted by weight.
 
-        :param str attr: Attribute name of the specifications dict. The
+        :param str attr: Attribute name of the specification's dict. The
             specifications must themselves have a `weight` attribute.
         """
         return sorted(getattr(self, attr).values(), key=lambda spec: spec.weight)

--- a/src/kerko/composer.py
+++ b/src/kerko/composer.py
@@ -327,9 +327,30 @@ class Composer:
             )
         )
         # Formatted citation.
+        #self.add_field(
+        #    FieldSpec(
+        #        key='bib',
+        #        field_type=STORED,
+        #        extractor=extractors.ItemExtractor(key='bib', format_='bib'),
+        #    )
+        #)
+        #Custom citation using csl(to be built)
+        for style in config_get(config,'kerko.zotero.csl_style'):
+            self.add_field(
+                FieldSpec(
+                    key='cite_'+style,
+                    field_type=STORED,
+                    extractor=extractors.ChainExtractor(
+                        extractors=[
+                            extractors.ConvertCitationExtractor(targetFormat=style),
+                            extractors.ItemExtractor(key='bib', format_='bib'),
+                    ]
+                ),
+            )
+        )
         self.add_field(
             FieldSpec(
-                key='bib',
+                key='cite',
                 field_type=STORED,
                 extractor=extractors.ItemExtractor(key='bib', format_='bib'),
             )

--- a/src/kerko/composer.py
+++ b/src/kerko/composer.py
@@ -335,7 +335,11 @@ class Composer:
                 FieldSpec(
                     key='cite_' + style,
                     field_type=STORED,
-                    extractor=extractors.ConvertCitationExtractor(targetFormat=style)
+                    extractor=extractors.ConvertCitationExtractor(
+                        target_format=style,
+                        max_attempts=config_get(config, 'kerko.zotero.max_attempts'),
+                        wait=config_get(config, 'kerko.zotero.wait')
+                    )
                 ),
             )
 

--- a/src/kerko/config_helpers.py
+++ b/src/kerko/config_helpers.py
@@ -151,7 +151,7 @@ class ZoteroModel(BaseModel):
     batch_size: int = Field(ge=20)
     max_attempts: int = Field(ge=1)
     wait: int = Field(ge=120)
-    csl_style: str
+    csl_style: List[str]
     locale: str = Field(regex=r'^[a-z]{2}-[A-Z]{2}$')
     item_include_re: str
     item_exclude_re: str

--- a/src/kerko/config_helpers.py
+++ b/src/kerko/config_helpers.py
@@ -162,16 +162,6 @@ class ZoteroModel(BaseModel):
     attachment_mime_types: List[str]
 
 
-class PerformanceModel(BaseModel):
-    """Model for the kerko.performance config table."""
-
-    class Config:
-        extra = Extra.forbid
-
-    whoosh_index_memory_limit: int = Field(ge=16)
-    whoosh_index_processors: int = Field(ge=1)
-
-
 class SearchModel(BaseModel):
     """Model for the kerko.search config table."""
 
@@ -430,6 +420,11 @@ class LinkGroupsModel(BaseModel):  # TODO: Pydantic v2: inherit RootModel.
             for key, links in self.__root__.items()
         }
 
+class BrandModel(BaseModel): #Brand Configuration Model(Local Dev)
+
+    url: str
+    width: int
+    height: int
 
 class KerkoModel(BaseModel):
     """Model for the kerko config table."""
@@ -441,12 +436,12 @@ class KerkoModel(BaseModel):
     features: FeaturesModel
     feeds: FeedsModel
     meta: MetaModel
+    brand: BrandModel
     pagination: PaginationModel
     breadcrumb: BreadcrumbModel
     link_groups: LinkGroupsModel
     templates: TemplatesModel
     zotero: ZoteroModel
-    performance: PerformanceModel
     search: SearchModel
     scopes: Dict[SlugStr, ScopesModel]
     search_fields: SearchFieldsModel

--- a/src/kerko/config_helpers.py
+++ b/src/kerko/config_helpers.py
@@ -150,7 +150,7 @@ class ZoteroModel(BaseModel):
 
     batch_size: int = Field(ge=20)
     max_attempts: int = Field(ge=1)
-    wait: int = Field(ge=120)
+    wait: int = Field(ge=10)
     csl_style: List[str]
     locale: str = Field(regex=r'^[a-z]{2}-[A-Z]{2}$')
     item_include_re: str

--- a/src/kerko/default_config.toml
+++ b/src/kerko/default_config.toml
@@ -858,8 +858,3 @@ whoosh_language = "en"
     [kerko.relations.related]
     enabled = true
     weight = 20
-
-[kerko.performance]
-
-whoosh_index_memory_limit = 128
-whoosh_index_processors = 1

--- a/src/kerko/extractors.py
+++ b/src/kerko/extractors.py
@@ -732,21 +732,30 @@ class SortDateExtractor(Extractor):
 
 # Citation generation
 class ConvertCitationExtractor(Extractor):
+    CITATION_STYLE_DICT = {
+        'APA': 'apa',
+        'ABNT': 'associacao-brasileira-de-normas-tecnicas'
+    }
+
+
     def apply_transformers(self, item, target):
-        transformer = self.getTransformer(target)
-        return transformer(item)
+        return self.getTransformer(item, target)
 
-    def getTransformer(self, target):
-        if (target == 'apa'):
-            return self.apa_transformer
-        elif (target == 'abnt'):
-            return self.abnt_transformer
 
-    def apa_transformer(self, value):
-        return value
+    def getTransformer(self, item, target):
+        if(target in ConvertCitationExtractor.CITATION_STYLE_DICT)
+            return self.getZoteroCitation(item, ConvertCitationExtractor.CITATION_STYLE_DICT[target])
+        else
+            return self.getZoteroCitation(item, target)
 
-    def abnt_transformer(self, value):
-        return 'Future conversion to abnt'
+    def getZoteroCitation(self, item, target):
+        from kerko.sync import zotero
+        api = zotero.init_zotero()
+        api.add_parameters({
+            'include': 'citation',
+            'style': target
+        })
+        return api.item(item.get('key'))['data']['citation']
 
     def __init__(self, *, targetFormat, **kwargs):
         """

--- a/src/kerko/extractors.py
+++ b/src/kerko/extractors.py
@@ -728,3 +728,37 @@ class SortDateExtractor(Extractor):
         parsed_date = item.get('meta', {}).get('parsedDate', '')
         year, month, day = parse_partial_date(parsed_date)
         return int('{:04d}{:02d}{:02d}'.format(year, month, day))
+#Citation generation
+class ConvertCitationExtractor(Extractor):
+    def apply_transformers(self, item, target):
+        transformer = self.getTransformer(target)
+        return transformer(item)
+
+    def getTransformer(self, target):
+        if(target == 'apa'):
+            return self.apa_transformer
+        elif(target == 'abnt'):
+            return self.abnt_transformer
+
+    def apa_transformer(self, value):
+        return value
+
+    def abnt_transformer(self, value):
+        return 'Future conversion to abnt'
+
+    def __init__(self, *, targetFormat, **kwargs):
+        """
+        Initialize the extractor.
+
+        :param Extractor extractor: Base extractor to wrap.
+
+        :param list transformers: List of callables that will be chained to
+            transform the extracted data. Each callable takes a value as
+            argument and returns the transformed value.
+        """
+        super().__init__(**kwargs)
+        self.targetFormat = targetFormat
+
+    def extract(self, item, library_context, spec):
+        value = item.get('bib')
+        return self.apply_transformers(value, self.targetFormat)

--- a/src/kerko/extractors.py
+++ b/src/kerko/extractors.py
@@ -756,7 +756,7 @@ class ConvertCitationExtractor(Extractor):
         attempts = 1
         while True:
             try:
-                return api.item(item, content='citation', style=target)[0]
+                return api.item(item, content='bib', style=target)[0]
             except (
                     requests.exceptions.ConnectionError,
                     zotero_errors.HTTPError,

--- a/src/kerko/sync/cache.py
+++ b/src/kerko/sync/cache.py
@@ -51,10 +51,7 @@ def sync_cache(full=False):
     version = zotero.last_modified_version(zotero_credentials)
 
     cache = open_index('cache', schema=get_cache_schema, auto_create=True, write=True)
-    writer = cache.writer(
-        limitmb=config('kerko.performance.whoosh_index_memory_limit'),
-        procs=config('kerko.performance.whoosh_index_processors'),
-    )
+    writer = cache.writer(limitmb=256)
     try:
         if config('kerko.search.fulltext'):
             fulltext_items = zotero.load_new_fulltext(zotero_credentials, since)

--- a/src/kerko/sync/index.py
+++ b/src/kerko/sync/index.py
@@ -42,10 +42,7 @@ def sync_index(full=False):
 
     count = 0
     index = open_index('index', schema=composer().schema, auto_create=True, write=True)
-    writer = index.writer(
-        limitmb=config('kerko.performance.whoosh_index_memory_limit'),
-        procs=config('kerko.performance.whoosh_index_processors'),
-    )
+    writer = index.writer(limitmb=256)
     try:
         writer.mergetype = whoosh.writing.CLEAR
         gate = TagGate(

--- a/src/kerko/sync/zotero.py
+++ b/src/kerko/sync/zotero.py
@@ -344,7 +344,7 @@ class Items:
             'sort': 'dateAdded',
             'direction': 'asc',
             'include': self.include,
-            'style': config('kerko.zotero.csl_style'),
+            'style': config('kerko.zotero.csl_style')[0],
         }
         self.zotero_batch = getattr(self.zotero_credentials, self.method)(**params)
         if not self.zotero_batch:

--- a/src/kerko/templates/kerko/_navbar_brand.html.jinja2
+++ b/src/kerko/templates/kerko/_navbar_brand.html.jinja2
@@ -1,1 +1,4 @@
-<a href="{{ url_for('kerko.search') }}" class="navbar-brand">{{ config.kerko.meta.title }}</a>
+<a href="{{ url_for('kerko.search') }}" class="navbar-brand">
+  <img src="{{ config.kerko.brand.url }}" width="{{ config.kerko.brand.width }}" height="{{ config.kerko.brand.height }}" class="d-inline-block align-top" alt="">
+  {{ config.kerko.meta.title }}
+</a>

--- a/src/kerko/templates/kerko/item.html.jinja2
+++ b/src/kerko/templates/kerko/item.html.jinja2
@@ -181,7 +181,9 @@
             {{- field(_("Notes"), item.notes|join('')|safe) if item.notes }}
         {%- endblock item_field_notes %}
         {%- block item_field_citation %}
-            {{- field(_("Citation"), ('<div class="card"><div class="card-body">' + item.bib + '</div></div>')|safe) }}
+        {%- for csl in config.kerko.zotero.csl_style %}
+            {{- field(_("Citation '" + csl + "'"), ('<div class="card"><div class="card-body">' + item.get('cite_'+csl) + '</div></div>')|safe) }}
+        {%- endfor -%}
         {%- endblock item_field_citation %}
         {%- block item_facets %}
             {%- if item.facet_results %}


### PR DESCRIPTION
Change to allow to configure multiple citation styles and display them separately

for that added on a new extractor a call to zotero api getting the 'bib' for all styles configured.
also changed the setting definition for csl_style from str to List<str>

Any advice or changes to the logic is welcome.