### PR TITLE
Add support for capturing group in tag inclusion.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "dpath >= 2.1.0",
     "Flask >= 2.2.5",
     "Flask-Babel >= 3.0.1",
+    "Flask-Caching >= 2.3.0",
     "Flask-WTF >= 0.14.2",
     "Jinja2 >= 3.0.1",
     "pycountry >= 24",

--- a/src/kerko/blueprint.py
+++ b/src/kerko/blueprint.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import shutil
 from functools import partial
 
@@ -31,7 +32,8 @@ class Blueprint(BaseBlueprint):
 
     def _setup_cache(self, app: App) -> Cache:
         # Clear cache folder on startup
-        shutil.rmtree(".flask_cache")
+        if os.path.exists(".flask_cache"):
+            shutil.rmtree(".flask_cache")
         app.config["CACHE_TYPE"] = "filesystem"
         app.config["CACHE_DIR"] = ".flask_cache"
         app.config["CACHE_THRESHOLD"] = 10000

--- a/src/kerko/blueprint.py
+++ b/src/kerko/blueprint.py
@@ -1,29 +1,57 @@
+import hashlib
+import shutil
 from functools import partial
 
-from flask import Blueprint as BaseBlueprint
+from flask import Blueprint as BaseBlueprint, request
 from flask import Config
 from flask.app import App
+from flask_caching import Cache
 
 from kerko import jinja2
 from kerko.views.routes import page
 from kerko.views.urls import urls
 
 
+def make_cache_key():
+    """
+    Generate a cache key based on the request path and query parameters.
+    """
+    key = request.path.encode("utf-8") + b"?" + request.query_string
+    return hashlib.md5(key).hexdigest()
+
+
 class Blueprint(BaseBlueprint):
     def register(self, app: App, options: dict) -> None:
         jinja2.register_filters(self)
         jinja2.register_globals(self)
-        self._add_core_urls()
+        cache = self._setup_cache(app)
+        self._add_core_urls(cache)
         self._add_page_urls(app.config)
         super().register(app, options)
 
-    def _add_core_urls(self) -> None:
+    def _setup_cache(self, app: App) -> Cache:
+        # Clear cache folder on startup
+        shutil.rmtree(".flask_cache")
+        app.config["CACHE_TYPE"] = "filesystem"
+        app.config["CACHE_DIR"] = ".flask_cache"
+        app.config["CACHE_THRESHOLD"] = 10000
+        app.config["CACHE_DEFAULT_TIMEOUT"] = 0
+        return Cache(app)
+
+    def _add_core_urls(self, cache: Cache) -> None:
         """
         Register Kerko's URLs.
 
         This must be called before the blueprint is registered on the app.
         """
         for rule_kwargs in urls:
+            if rule_kwargs.pop("cache", False):
+                view_func = rule_kwargs.get("view_func")
+                # Cache only GET method
+                view_func = cache.cached(
+                    key_prefix=make_cache_key, unless=lambda: request.method != "GET"
+                )(view_func)
+                rule_kwargs["view_func"] = view_func
             self.add_url_rule(**rule_kwargs)
 
     def _add_page_urls(self, config: Config) -> None:
@@ -37,5 +65,7 @@ class Blueprint(BaseBlueprint):
                 self.add_url_rule(
                     rule=page_spec.path,
                     endpoint=key,
-                    view_func=partial(page, item_id=page_spec.item_id, title=page_spec.title),
+                    view_func=partial(
+                        page, item_id=page_spec.item_id, title=page_spec.title
+                    ),
                 )

--- a/src/kerko/blueprint.py
+++ b/src/kerko/blueprint.py
@@ -37,7 +37,7 @@ class Blueprint(BaseBlueprint):
         app.config["CACHE_TYPE"] = "filesystem"
         app.config["CACHE_DIR"] = ".flask_cache"
         app.config["CACHE_THRESHOLD"] = 10000
-        app.config["CACHE_DEFAULT_TIMEOUT"] = 0
+        app.config["CACHE_DEFAULT_TIMEOUT"] = 86400  # 1 day in seconds
         return Cache(app)
 
     def _add_core_urls(self, cache: Cache) -> None:

--- a/src/kerko/composer.py
+++ b/src/kerko/composer.py
@@ -606,6 +606,26 @@ class Composer:
                             **kwargs,
                         )
                     )
+                elif facet_type == "tag_based_facet":
+                    include_re = kwargs.pop("tag_include_re")
+                    exclude_re = kwargs.pop("tag_exclude_re")
+                    exclude_re = "" if exclude_re is None else exclude_re
+                    self.add_facet(
+                        FlatFacetSpec(
+                            key=f"facet_{facet_key}",
+                            field_type=ID(stored=True),
+                            extractor=extractors.TagsFacetExtractor(
+                                include_re=include_re,
+                                exclude_re=exclude_re,
+                            ),
+                            codec=codecs.BaseFacetCodec(),
+                            title=facet_config.get("title") or _("Topic"),
+                            missing_label=None,  # TODO:config: Allow in config.
+                            allow_overlap=True,
+                            query_class=Term,
+                            **kwargs,
+                        )
+                    )
                 elif facet_type == "item_type":
                     self.add_facet(
                         FlatFacetSpec(

--- a/src/kerko/composer.py
+++ b/src/kerko/composer.py
@@ -106,8 +106,8 @@ class Composer:
             "creator": _("In authors or contributors"),
             "title": _("In titles"),
             "pubyear": _("In publication years"),
-            "metadata": _("In all fields"),
-            "fulltext": _("In documents"),
+            "metadata": _("In all fields (abstract and more)"),
+            "fulltext": _("In documents (full-text)"),
         }
         breadbox_label = {
             "all": _("Everywhere"),

--- a/src/kerko/config_helpers.py
+++ b/src/kerko/config_helpers.py
@@ -171,7 +171,7 @@ class ZoteroModel(BaseModel):
 
     batch_size: int = Field(ge=20)
     max_attempts: int = Field(ge=1)
-    wait: int = Field(ge=120)
+    wait: int = Field(ge=10)
     csl_style: str
     locale: str = Field(regex=r"^[a-z]{2,3}-[A-Za-z]+$")
     item_include_re: str

--- a/src/kerko/config_helpers.py
+++ b/src/kerko/config_helpers.py
@@ -296,6 +296,14 @@ class TagFacetModel(BaseFacetModel):
     title: Optional[str]
 
 
+class TagBasedFacetModel(BaseFacetModel):
+
+    type: Literal["tag_based_facet"]  # noqa: A003
+    title: Optional[str]
+    tag_include_re: str
+    tag_exclude_re: Optional[str]
+
+
 class ItemTypeFacetModel(BaseFacetModel):
     type: Literal["item_type"]  # noqa: A003
     title: Optional[str]
@@ -337,6 +345,7 @@ class CollectionFacetModel(BaseFacetModel):
 FacetModelUnion = Annotated[
     Union[
         TagFacetModel,
+        TagBasedFacetModel,
         ItemTypeFacetModel,
         YearFacetModel,
         LanguageFacetModel,

--- a/src/kerko/default_config.toml
+++ b/src/kerko/default_config.toml
@@ -84,7 +84,7 @@ atom_feed = "kerko/atom.xml.jinja2"
 
 batch_size = 100
 max_attempts = 10
-wait = 120  # In seconds.
+wait = 10  # In seconds.
 
 csl_style = "apa"
 locale = "en-US"

--- a/src/kerko/forms.py
+++ b/src/kerko/forms.py
@@ -9,6 +9,10 @@ class SearchForm(FlaskForm):
     scope = SelectField()
     keywords = SearchField(validators=[validators.optional(), validators.length(max=1000)])
 
+    # https://stackoverflow.com/a/54719911
+    class Meta:
+        csrf = False
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.scope.choices = [

--- a/src/kerko/searcher.py
+++ b/src/kerko/searcher.py
@@ -1,6 +1,7 @@
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from datetime import datetime, timedelta
 from itertools import chain
 
 from flask_babel import gettext
@@ -234,10 +235,14 @@ class Searcher:
 class SearcherSingleton(Searcher):
     _instance = None
     _initialized = False
+    _last_created = datetime.now()
 
     def __new__(cls, *args, **kwargs):
-        if not cls._instance:
+        if not cls._instance or datetime.now() - cls._last_created > timedelta(hours=12):
+            if cls._instance:
+                cls._instance.close()
             cls._instance = super(SearcherSingleton, cls).__new__(cls)
+            cls._last_created = datetime.now()
         return cls._instance
 
     def __init__(self, schema=None, field_specs=None, facet_specs=None):

--- a/src/kerko/shortcuts.py
+++ b/src/kerko/shortcuts.py
@@ -1,3 +1,4 @@
+import functools
 import pathlib
 from typing import Any
 
@@ -23,6 +24,7 @@ def data_path() -> str:
     return str(instance_path / config_data_path)
 
 
+@functools.lru_cache
 def config(path: str) -> Any:
     """
     Retrieve an arbitrarily nested setting from the current_app's configuration.

--- a/src/kerko/specs.py
+++ b/src/kerko/specs.py
@@ -239,32 +239,35 @@ class FacetSpec(BaseFieldSpec):
         :param active_only: Only build the items that are related to active
             filters, i.e., filters actually present in the search criteria.
         """
+    
+    def _compute_sort_key(self, item):
+        """
+        Precompute the sort keys for each item to avoid repeated computations
+        """
+        # First sort key: show active items first.
+        active_first = not item["remove_url"]
+        # Second sort key: show items with missing labels last.
+        missing_label_last = bool(item["label"]) if self.sort_reverse else not item["label"]
+        # Third sort key: sort items according to the facet's specified
+        # sort keys. If 'count' is used as key, multiply the count value
+        # by -1 to reverse order (because the desired default when
+        # ordering by count is the descending order).
+        sort_keys = [
+            item[k] * -1 if k == "count" else (sort_normalize(item[k]) if isinstance(item[k], str) else item[k])
+            for k in self.sort_by
+        ]
+        return (active_first, missing_label_last, *sort_keys)
 
     def sort_items(self, items):
         if self.sort_by is None:
             return items
-
-        # Sort items based on multiple-keys.
-        return sorted(
-            items,
-            key=lambda x: (
-                # First sort key: show active items first.
-                not x["remove_url"],
-                # Second sort key: show items with missing labels last.
-                bool(x["label"]) if self.sort_reverse else not x["label"],
-                # Third sort key: sort items according to the facet's specified
-                # sort keys. If 'count' is used as key, multiply the count value
-                # by -1 to reverse order (because the desired default when
-                # ordering by count is the descending order).
-                *[
-                    x[k] * -1
-                    if k == "count"
-                    else (sort_normalize(x[k]) if isinstance(x[k], str) else x[k])
-                    for k in self.sort_by
-                ],
-            ),
-            reverse=self.sort_reverse,
-        )
+    
+        # Compute sort keys for all items
+        items_with_keys = [(self._compute_sort_key(item), item) for item in items]
+        # Sort items based on the precomputed keys
+        sorted_items = sorted(items_with_keys, key=lambda x: x[0], reverse=self.sort_reverse)
+        # Extract the sorted items
+        return [item for _, item in sorted_items]
 
     def render(self, items, mode):
         return self.renderer.render(spec=self, items=items, mode=mode)
@@ -294,42 +297,26 @@ class FlatFacetSpec(FacetSpec):
 
     def build(self, results, criteria, active_only=False):
         items = []
+        cached_params = criteria.params(options={"page": None, "page-len": None, "id": None})
+
         for value, count in results.items():
             if value or self.missing_label:
                 value, label = self.decode(value, default_value=value, default_label=value)  # noqa: PLW2901
-                new_filters = self.remove_filter(value, criteria.filters)
-                if new_filters:
-                    remove_url = url_for(
-                        ".search",
-                        **criteria.params(
-                            filters=new_filters,
-                            options={
-                                "page": None,
-                                "page-len": None,
-                                "id": None,
-                            },
-                        ),
-                    )
-                else:
-                    remove_url = None
-                if remove_url or active_only:
-                    add_url = None
-                else:
-                    new_filters = self.add_filter(value, criteria.filters)
-                    if new_filters:
-                        add_url = url_for(
-                            ".search",
-                            **criteria.params(
-                                filters=new_filters,
-                                options={
-                                    "page": None,
-                                    "page-len": None,
-                                    "id": None,
-                                },
-                            ),
-                        )
-                    else:
-                        add_url = None
+                new_filters_remove = self.remove_filter(value, criteria.filters)
+                new_filters_add = self.add_filter(value, criteria.filters)
+
+                remove_url = (
+                    url_for(".search", **{**cached_params, "filters": new_filters_remove})
+                    if new_filters_remove
+                    else None
+                )
+
+                add_url = (
+                    url_for(".search", **{**cached_params, "filters": new_filters_add})
+                    if new_filters_add and not (remove_url or active_only)
+                    else None
+                )
+
                 if remove_url or add_url:  # Only items with an URL get displayed.
                     items.append(
                         {
@@ -340,6 +327,7 @@ class FlatFacetSpec(FacetSpec):
                             "add_url": add_url,
                         }
                     )
+
         return self.sort_items(items)
 
 
@@ -428,6 +416,7 @@ class TreeFacetSpec(FacetSpec):
 
     def build(self, results, criteria, active_only=False):
         tree = Tree()
+        cached_options={"page": None, "page-len": None, "id": None}
         for value, count in results.items():
             if value or self.missing_label:
                 value, label = self.decode(value, default_value=value, default_label=value)  # noqa: PLW2901
@@ -437,11 +426,7 @@ class TreeFacetSpec(FacetSpec):
                         ".search",
                         **criteria.params(
                             filters=new_filters,
-                            options={
-                                "page": None,
-                                "page-len": None,
-                                "id": None,
-                            },
+                            options=cached_options,
                         ),
                     )
                 else:
@@ -455,11 +440,7 @@ class TreeFacetSpec(FacetSpec):
                             ".search",
                             **criteria.params(
                                 filters=new_filters,
-                                options={
-                                    "page": None,
-                                    "page-len": None,
-                                    "id": None,
-                                },
+                                options=cached_options,
                             ),
                         )
                     else:

--- a/src/kerko/static/kerko/css/styles.css
+++ b/src/kerko/static/kerko/css/styles.css
@@ -87,3 +87,13 @@ main {
 .d-none-important {
   display: none !important;
 }
+
+.facet-item {
+  margin-left: 20px;
+}
+.facet-item .add-remove-icon {
+  line-height: 1.5;
+  margin-left: 1px;
+  top: -1px;
+  left: -20px;
+}

--- a/src/kerko/sync/__init__.py
+++ b/src/kerko/sync/__init__.py
@@ -1,1 +1,11 @@
 """Synchronization module."""
+
+import functools
+
+from kerko.storage import load_object
+
+
+@functools.lru_cache
+def kerko_last_sync():
+    last_sync = load_object("index", "last_update_from_zotero")
+    return last_sync

--- a/src/kerko/templates/kerko/_facets.html.jinja2
+++ b/src/kerko/templates/kerko/_facets.html.jinja2
@@ -22,16 +22,16 @@
         )
     -%}
     {%- if item.label or missing_label -%}
-        <{{ item_tag }}{% if icon_left %} class="position-relative"{% endif %}{% if top_level and icon_left %} style="margin-left:{{ icon_left }};"{% endif %}>
+        <{{ item_tag }}{% if icon_left %} class="position-relative {% if top_level %}facet-item{% endif %}"{% endif %}>
             {%- set label = item.label|escape|trim(' _') or (('<em>' + missing_label + '</em>')|safe) -%}
             {%- if item.remove_url -%}
                 <a class="no-decorate" href="{{ item.remove_url }}" {{ title_aria_label(remove_title.format(label|striptags|escape)) }} rel="nofollow">
-                    {%- if remove_icon %}<span class="far fa-check-square{% if icon_left %} position-absolute{% endif %}" aria-hidden="true"{% if icon_left %} style="margin-left:1px;{% if icon_top %}top:{{ icon_top }};{% endif %}left:-{{ icon_left }};{% if icon_line_height %}line-height:1.5;{% endif %}"{% endif %}></span>{% endif %}
+                    {%- if remove_icon %}<span class="far fa-check-square{% if icon_left %} position-absolute add-remove-icon{% endif %}" aria-hidden="true"{% if icon_left %} {% endif %}></span>{% endif %}
                     <span class="facet-item-label parent-decorate">{{ label }}</span>{#- No whitespace -#}
                 </a>
             {%- elif item.add_url -%}
                 <a class="no-decorate" href="{{ item.add_url }}" {{ title_aria_label(add_title.format(label|striptags|escape)) }} rel="nofollow">
-                    {%- if add_icon %}<span class="far fa-square{% if icon_left %} position-absolute{% endif %}" aria-hidden="true"{% if icon_left %} style="margin-left:1px;{% if icon_top %}top:{{ icon_top }};{% endif %}left:-{{ icon_left }};{% if icon_line_height %}line-height:1.5;{% endif %}"{% endif %}></span>{% endif %}
+                    {%- if add_icon %}<span class="far fa-square{% if icon_left %} position-absolute add-remove-icon{% endif %}" aria-hidden="true"{% if icon_left %} {% endif %}></span>{% endif %}
                     <span class="facet-item-label parent-decorate">{{ label }}</span>{#- No whitespace -#}
                 </a>
             {%- else -%}

--- a/src/kerko/templates/kerko/item.html.jinja2
+++ b/src/kerko/templates/kerko/item.html.jinja2
@@ -265,7 +265,7 @@
 {%- endblock content_inner %}
 
 {%- block content_footer %}
-    {%- if config.DEBUG %}
+    {%- if config.DEBUG or config.SHOW_PROCESSING_TIME %}
         <div class="text-right mb-4 mt-2 text-muted">{% trans time="%.2f"|format(time) %}Processing time: {{time}} seconds{% endtrans %}</div>
     {%- endif %}
 {%- endblock content_footer %}

--- a/src/kerko/templates/kerko/layout.html.jinja2
+++ b/src/kerko/templates/kerko/layout.html.jinja2
@@ -25,7 +25,7 @@
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/fontawesome.css" integrity="sha384-sri+NftO+0hcisDKgr287Y/1LVnInHJ1l+XC7+FOabmTTIK0HnE2ID+xxvJ21c5J" crossorigin="anonymous">
     {%- endblock fontawesome_css %}
     {%- block kerko_css %}
-        <link rel="stylesheet" href="{{ url_for('kerko.static', filename='kerko/css/styles.css') }}?20230626">
+        <link rel="stylesheet" href="{{ url_for('kerko.static', filename='kerko/css/styles.css') }}?20240928">
     {%- endblock kerko_css %}
 {%- endblock styles %}
 

--- a/src/kerko/templates/kerko/search.html.jinja2
+++ b/src/kerko/templates/kerko/search.html.jinja2
@@ -154,7 +154,7 @@
                     </div>
                 {%- endif %}
                 <div class="text-right mb-4 text-muted d-print-none">
-                    {%- if config.DEBUG %}
+                    {%- if config.DEBUG or config.SHOW_PROCESSING_TIME %}
                         {% trans time="%.2f"|format(time) %}Processing time: {{ time }} seconds{% endtrans %} &mdash;
                     {%- endif %}
                     {%- if last_sync %}

--- a/src/kerko/templates/kerko/search.html.jinja2
+++ b/src/kerko/templates/kerko/search.html.jinja2
@@ -181,9 +181,7 @@
             <div id="facets-container" class="d-none d-lg-block d-print-none">
                 <h2 class="{% block facets_heading_classes %}mt-2 mb-4{% endblock %}">{{ _("Explore") }}</h2>
                 <div id="facets" class="facets">
-                    {%- for f in config.kerko_composer.get_ordered_specs('facets') %}
-                        {{ f.render(facet_results[f.key], 'search') }}
-                    {%- endfor %}
+                    {{ facet_results|safe }}
                 </div>
             </div>
             <div id="facets-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="facets-modal-label" aria-hidden="true">

--- a/src/kerko/views/item/relations.py
+++ b/src/kerko/views/item/relations.py
@@ -1,6 +1,5 @@
-from kerko.searcher import Searcher
+from kerko.searcher import SearcherSingleton
 from kerko.shortcuts import composer, config
-from kerko.storage import open_index
 
 
 def _get_forward_rel_filters(item, relation_spec):
@@ -61,8 +60,7 @@ def inject_relations(item):
             if key != "coins"
         ],
     )
-    index = open_index("index")
-    with Searcher(index) as searcher:
+    with SearcherSingleton() as searcher:
         for relation_spec in composer().relations.values():
             if relation_spec.directed:
                 item[relation_spec.field.key] = searcher.search(

--- a/src/kerko/views/routes.py
+++ b/src/kerko/views/routes.py
@@ -28,8 +28,8 @@ from kerko.storage import (
     SearchIndexError,
     get_doc_count,
     get_storage_dir,
-    load_object,
 )
+from kerko.sync import kerko_last_sync
 from kerko.views import pager
 from kerko.views.item import build_item_context, creators, inject_item_data
 from kerko.views.search import search_list, search_single
@@ -128,7 +128,7 @@ def atom_feed():
         criteria.fit_page(results.page_count or 1)
         pager_sections = pager.get_sections(criteria.options["page"], results.page_count or 1)
 
-    last_sync = load_object("index", "last_update_from_zotero")
+    last_sync = kerko_last_sync()
     if last_sync:
         context["last_sync"] = datetime.fromtimestamp(
             last_sync, tz=datetime.now().astimezone().tzinfo
@@ -485,7 +485,7 @@ def sitemap(page_num):
 
 
 def last_updated_on():
-    last_sync = load_object("index", "last_update_from_zotero")
+    last_sync = kerko_last_sync()
     if last_sync:
         return {
             "when": datetime.fromtimestamp(

--- a/src/kerko/views/search.py
+++ b/src/kerko/views/search.py
@@ -7,9 +7,9 @@ from flask_babel import get_locale, gettext, ngettext
 from werkzeug.datastructures import MultiDict
 
 from kerko.criteria import create_feed_criteria
-from kerko.searcher import Searcher
+from kerko.searcher import SearcherSingleton
 from kerko.shortcuts import composer, config
-from kerko.storage import load_object, open_index
+from kerko.storage import load_object
 from kerko.views import breadbox, pager, sorter
 from kerko.views.item import build_item_context, inject_item_data
 
@@ -49,8 +49,7 @@ def empty_results(criteria, form):
         # separate search query for each active facet, each time ignoring all
         # other search criteria. Unless a given facet value alone leads to empty
         # results, we'll be able to get to build that facet.
-        index = open_index("index")
-        with Searcher(index) as searcher:
+        with SearcherSingleton() as searcher:
             for key, value in criteria.filters.lists():
                 results = searcher.search(
                     filters=MultiDict({key: value}),
@@ -73,8 +72,7 @@ def search_single(criteria, form):
     """Perform search, and prepare template context for a results page containing a single item."""
     start_time = time.process_time()
     context = {}
-    index = open_index("index")
-    with Searcher(index) as searcher:
+    with SearcherSingleton() as searcher:
         results = searcher.search_page(
             page=criteria.options.get("page", 1),
             page_len=1,
@@ -152,8 +150,7 @@ def search_list(criteria, form):
     """Perform search, and prepare the template context variables for a list of search results."""
     start_time = time.process_time()
     context = {}
-    index = open_index("index")
-    with Searcher(index) as searcher:
+    with SearcherSingleton() as searcher:
         page_len = criteria.options.get("page-len", config("kerko.pagination.page_len"))
         common_search_args = {
             "keywords": criteria.keywords,

--- a/src/kerko/views/search.py
+++ b/src/kerko/views/search.py
@@ -9,7 +9,7 @@ from werkzeug.datastructures import MultiDict
 from kerko.criteria import create_feed_criteria
 from kerko.searcher import SearcherSingleton
 from kerko.shortcuts import composer, config
-from kerko.storage import load_object
+from kerko.sync import kerko_last_sync
 from kerko.views import breadbox, pager, sorter
 from kerko.views.item import build_item_context, inject_item_data
 
@@ -253,7 +253,7 @@ def search_list(criteria, form):
         context["facet_results"] = results_facets
         context["breadbox"] = breadbox.build_breadbox(criteria, results_facets)
 
-        last_sync = load_object("index", "last_update_from_zotero")
+        last_sync = kerko_last_sync()
         if last_sync:
             context["last_sync"] = datetime.fromtimestamp(
                 last_sync,

--- a/src/kerko/views/search.py
+++ b/src/kerko/views/search.py
@@ -250,7 +250,10 @@ def search_list(criteria, form):
         items = results.items(field_specs)
         results_facets = results.facets(composer().facets, criteria)
         context["search_results"] = zip(items, _build_item_search_urls(items, criteria))
-        context["facet_results"] = results_facets
+        context["facet_results"] = "".join(
+            spec.render(results_facets[spec.key], "search")
+            for spec in composer().get_ordered_specs("facets")
+        )
         context["breadbox"] = breadbox.build_breadbox(criteria, results_facets)
 
         last_sync = kerko_last_sync()

--- a/src/kerko/views/urls.py
+++ b/src/kerko/views/urls.py
@@ -6,6 +6,7 @@ urls = [
         "rule": "/",
         "view_func": routes.search,
         "methods": ["GET", "POST"],
+        "cache": True,
     },
     {
         "rule": "/atom.xml",


### PR DESCRIPTION
Re-worked PR. It allows the use of capturing group when using regular expression to determine item inclusion by tags.
If `tag_include_re` contains a named capture group `kerko`, the capture will be used.

For example, in Zotero, a reference has tags of "-tag-Topic 1" and "-tag-Topic 2".

- In config.toml, set `tag_include_re` to "-tag-(?P\<kerko\>.*)".
- In the web, facets will be "Topic 1" and "Topic 2", instead of "-tag-Topic 1", "-tag-Topic 2".

If `tag_include_re` does not include a capture group of name "kerko", or if it does not include any capture groups, then the full tags will be used if matched.

- In config.toml, set `tag_include_re` to "-tag-(?P\<anotherName\>.*)", or "-tag-".
- In the web, facets will be "-tag-Topic 1", "-tag-Topic 2".

This ensures that we can have some tags in Zotero for private use while some others specifically for creating facets.
