### PR TITLE
Fix five assorted bugs (link URL escaping, index sync error reporting, page ranges, year facet label, searcher state)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Changes:
 
 - Add Galician (gl) translation. Thanks to Gonçalo Cordeiro.
 
+Bug fixes:
+
+- Escape and sanitize the URLs of an item's attached links before inserting
+  them into the `href` attribute on item pages.
+- Report the underlying error when the cache database engine cannot be created
+  during an index synchronization, instead of failing with an
+  `UnboundLocalError` from the cleanup code.
+- Correctly split page ranges that use an en-dash, e.g., "5–7", in the Highwire
+  Press meta tags. Such ranges yielded an erroneous `citation_firstpage` and no
+  `citation_lastpage`.
+- Use the "In {year}" label instead of "Between {year} and {year}" for a
+  publication year facet whose range is truncated to a single year.
+- Reset the search arguments between successive searches performed with a same
+  `Searcher` instance, preventing the filters, sorting, or faceting of a search
+  from applying to the next one.
+
 
 ## 1.4.0alpha0 (2026-02-27)
 

--- a/src/kerko/codecs.py
+++ b/src/kerko/codecs.py
@@ -207,6 +207,6 @@ class YearTreeFacetCodec(BaseFacetCodec):
             end = int(path[1]) + 9
         if end >= datetime.datetime.now().year:
             end = datetime.datetime.now().year
-            if start == end:
+            if int(start) == end:
                 return encoded_value, _("In {}").format(end)
         return encoded_value, _("Between {} and {}").format(start, end)

--- a/src/kerko/index.py
+++ b/src/kerko/index.py
@@ -130,8 +130,8 @@ def sync_index(full: bool = False) -> None:
     index_version = load_object("index_version", default=None)
     index_cache_timestamp = load_object("cache_timestamp", default=None)
 
+    cache_engine = create_engine(cache_url)
     try:
-        cache_engine = create_engine(cache_url)
         with Session(cache_engine) as cache_session:
             cache_status = CacheStatus(cache_session)
             if full or cache_status.is_fresh(index_version, index_cache_timestamp):

--- a/src/kerko/searcher.py
+++ b/src/kerko/searcher.py
@@ -86,6 +86,10 @@ class Searcher:
         :param bool faceting: Whether to compute groupings along with the search
             results.
         """
+        # Start from a clean slate, otherwise arguments prepared for an earlier
+        # search on this instance (filters, sorting, faceting) would silently
+        # apply to this one as well.
+        self.search_args = {}
         self._prepare_keywords(keywords)
         self._prepare_filters(filters, require_all, require_any, require_date_ranges, reject_any)
         self._prepare_sorting(sort_spec)

--- a/src/kerko/templates/kerko/item.html.jinja2
+++ b/src/kerko/templates/kerko/item.html.jinja2
@@ -173,7 +173,7 @@
                     <div class="col-md-8 col-lg-9 break-word">
                         <ul class="list-unstyled">
                             {%- for link in item.links %}
-                                <li><a href="{{ link.url }}" target="_blank" rel="noopener noreferrer">{{ link.title|escape }}</a></li>
+                                <li><a href="{{ link.url|kerko_url_sanitize|escape }}" target="_blank" rel="noopener noreferrer">{{ link.title|escape }}</a></li>
                             {%- endfor %}
                         </ul>
                     </div>

--- a/src/kerko/views/item/meta.py
+++ b/src/kerko/views/item/meta.py
@@ -38,7 +38,7 @@ def build_highwirepress_tags(item):
         pages = data.get("pages")
         if pages:
             pages = re.sub("[-\u2013]", "-", pages)  # Replace hyphens and en-dashes.
-            pages = [p.strip() for p in re.split(r"\W*-\W*", data["pages"], maxsplit=2)]
+            pages = [p.strip() for p in re.split(r"\W*-\W*", pages, maxsplit=2)]
             if pages and pages[0]:
                 tags.append(("citation_firstpage", pages[0]))
             if len(pages) > 1 and pages[1]:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for the codecs module.
+"""
+
+import unittest
+from unittest import mock
+
+from flask import Flask
+from flask_babel import Babel
+
+import kerko
+from kerko.codecs import YearTreeFacetCodec
+from kerko.config_helpers import config_update
+
+
+class YearTreeFacetCodecTestCase(unittest.TestCase):
+    """Test the labels produced by the year facet codec."""
+
+    CURRENT_YEAR = 2020
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        config_update(self.app.config, kerko.DEFAULTS)
+        self.app.register_blueprint(kerko.make_blueprint(), url_prefix="/bibliography")
+        Babel().init_app(self.app)
+        self.codec = YearTreeFacetCodec()
+
+    def decode_label(self, encoded_value):
+        """Return the decoded label, with the current year pinned for reproducibility."""
+        with self.app.app_context(), mock.patch("kerko.codecs.datetime") as mock_datetime:
+            mock_datetime.datetime.now.return_value.year = self.CURRENT_YEAR
+            _value, label = self.codec.decode(encoded_value)
+            return str(label)
+
+    def test_year(self):
+        self.assertEqual(self.decode_label("2000.2010.2015"), "2015")
+
+    def test_decade(self):
+        self.assertEqual(self.decode_label("2000.2010"), "Between 2010 and 2019")
+
+    def test_decade_ending_at_current_year(self):
+        self.assertEqual(self.decode_label("2000.2020"), "In 2020")
+
+    def test_decade_truncated_at_current_year(self):
+        self.assertEqual(self.decode_label("2000.2011"), "Between 2011 and 2020")
+
+    def test_century(self):
+        self.assertEqual(self.decode_label("1900"), "Between 1900 and 1999")
+
+    def test_century_ending_at_current_year(self):
+        self.assertEqual(self.decode_label("2020"), "In 2020")
+
+    def test_century_truncated_at_current_year(self):
+        self.assertEqual(self.decode_label("2000"), "Between 2000 and 2020")

--- a/tests/test_item_meta.py
+++ b/tests/test_item_meta.py
@@ -5,9 +5,13 @@ Tests for item meta tags.
 import unittest
 
 import elementpath  # For XPath 2.0 selectors.
+from flask import Flask
 from lxml import etree
 
+import kerko
+from kerko.config_helpers import config_update
 from kerko.views.item.creators import format_creator_name
+from kerko.views.item.meta import build_highwirepress_tags
 from tests.base import SyncIndexTestCase
 
 
@@ -43,6 +47,41 @@ class CreatorNameTestCase(unittest.TestCase):
             format_creator_name({"firstName": "", "lastName": ""}),
             "",
         )
+
+
+class HighwirePressPagesTestCase(unittest.TestCase):
+    """Unit tests for the page range in Highwire Press tags."""
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        config_update(self.app.config, kerko.DEFAULTS)
+        self.app.register_blueprint(kerko.make_blueprint(), url_prefix="/bibliography")
+        ctx = self.app.app_context()
+        ctx.push()
+
+    def get_pages(self, pages):
+        """Return the (firstpage, lastpage) tags for an item with the given Pages field."""
+        tags = dict(
+            build_highwirepress_tags(
+                {
+                    "id": "ITEM0001",
+                    "data": {"itemType": "journalArticle", "title": "Test item", "pages": pages},
+                }
+            )
+        )
+        return tags.get("citation_firstpage"), tags.get("citation_lastpage")
+
+    def test_hyphen(self):
+        self.assertEqual(self.get_pages("5-7"), ("5", "7"))
+
+    def test_en_dash(self):
+        self.assertEqual(self.get_pages("5–7"), ("5", "7"))
+
+    def test_en_dash_with_spaces(self):
+        self.assertEqual(self.get_pages("5 – 7"), ("5", "7"))
+
+    def test_single_page(self):
+        self.assertEqual(self.get_pages("5"), ("5", None))
 
 
 class ItemMetaTestCase(SyncIndexTestCase):

--- a/tests/test_item_view.py
+++ b/tests/test_item_view.py
@@ -1,0 +1,60 @@
+"""
+Tests for the item view templates.
+"""
+
+import unittest
+
+from flask import Flask
+from flask_babel import Babel
+from lxml import etree
+
+import kerko
+from kerko.config_helpers import config_update
+
+
+class ItemLinksTestCase(unittest.TestCase):
+    """Test the rendering of an item's attached links."""
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        config_update(self.app.config, kerko.DEFAULTS)
+        self.app.register_blueprint(kerko.make_blueprint(), url_prefix="/bibliography")
+        Babel().init_app(self.app)
+
+    def render_links(self, links):
+        """Render just the 'item_field_links' block of the item template."""
+        with self.app.test_request_context("/bibliography/"):
+            template = self.app.jinja_env.get_template("kerko/item.html.jinja2")
+            context = template.new_context({"item": {"links": links}})
+            return "".join(template.blocks["item_field_links"](context))
+
+    def get_anchor(self, links):
+        html = self.render_links(links)
+        tree = etree.fromstring(html, etree.HTMLParser())
+        anchors = tree.xpath("//a")
+        self.assertEqual(len(anchors), 1)
+        return anchors[0]
+
+    def test_ordinary_url(self):
+        anchor = self.get_anchor([{"url": "https://example.com/doc", "title": "Some document"}])
+        self.assertEqual(anchor.get("href"), "https://example.com/doc")
+        self.assertEqual(anchor.text, "Some document")
+
+    def test_url_with_quote_does_not_inject_attributes(self):
+        """A quote in the URL must not be able to introduce new HTML attributes."""
+        anchor = self.get_anchor(
+            [{"url": 'https://example.com/"onmouseover="boom()', "title": "Some document"}]
+        )
+        self.assertEqual(
+            sorted(anchor.keys()),
+            ["href", "rel", "target"],
+            "URL must not introduce additional attributes on the link",
+        )
+        self.assertNotIn('"', anchor.get("href"))
+
+    def test_url_with_angle_brackets_does_not_inject_markup(self):
+        """A URL must not be able to introduce new HTML elements."""
+        html = self.render_links(
+            [{"url": "https://example.com/<script>boom()</script>", "title": "Some document"}]
+        )
+        self.assertNotIn("<script>", html)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -1,0 +1,42 @@
+"""
+Integration tests for the searcher.
+"""
+
+from kerko.criteria import create_search_criteria
+from kerko.index import open_index
+from kerko.searcher import Searcher
+from kerko.shortcuts import composer
+from tests.base import SyncIndexTestCase
+
+
+class SearcherReuseTestCase(SyncIndexTestCase):
+    """Test that successive searches on a same Searcher are independent."""
+
+    fixture_name = "dummy"
+
+    def test_filters_do_not_persist(self):
+        """A filter given to a search must not apply to the next one."""
+        with Searcher(open_index()) as searcher:
+            unfiltered_count = searcher.search(limit=None).item_count
+            filtered_count = searcher.search(
+                limit=None,
+                require_all={"item_type": ["journalArticle"]},
+            ).item_count
+            self.assertLess(
+                filtered_count,
+                unfiltered_count,
+                "Test requires a filter that actually rejects some items",
+            )
+            self.assertEqual(searcher.search(limit=None).item_count, unfiltered_count)
+
+    def test_faceting_does_not_persist(self):
+        """Faceting requested for a search must not apply to the next one."""
+        with (
+            self.app.test_request_context(f"{self.url_prefix}/"),
+            Searcher(open_index()) as searcher,
+        ):
+            criteria = create_search_criteria()
+            faceted = searcher.search(limit=None, faceting=True)
+            self.assertNotEqual(faceted.facets(composer().facets, criteria), {})
+            unfaceted = searcher.search(limit=None, faceting=False)
+            self.assertEqual(unfaceted.facets(composer().facets, criteria), {})

--- a/tests/test_sync_index.py
+++ b/tests/test_sync_index.py
@@ -2,8 +2,10 @@
 Integration tests for data synchronization.
 """
 
+from unittest import mock
+
 from kerko.exceptions import CacheEmptyError
-from kerko.index import doc_count
+from kerko.index import doc_count, sync_index
 from tests.base import SyncIndexTestCase
 
 
@@ -33,3 +35,13 @@ class SyncIndexEmptyLibraryTestCase(SyncIndexTestCase):
     def test_sync(self):
         with self.assertRaises(CacheEmptyError):
             self.sync_index()
+
+    def test_sync_reports_engine_creation_failure(self):
+        """A failure to create the engine must not be masked by the cleanup code."""
+        error = RuntimeError("could not create engine")
+        with (
+            mock.patch("kerko.index.create_engine", side_effect=error),
+            self.assertRaises(RuntimeError) as context,
+        ):
+            sync_index(full=True)
+        self.assertIs(context.exception, error)


### PR DESCRIPTION
Five small, independent bug fixes found while reading through the code. Each is
its own commit with a test that fails without the corresponding patch, as
suggested in the contributing guidelines.

No linked issues: I searched the tracker first and none of these appear to have
been reported, and they seemed small enough not to warrant opening five issues
just to close them again. Happy to file them if you would prefer the traceability.

Each commit stands alone, so please feel free to take only the ones you agree with.

## 1. Attached link URLs are not escaped on item pages

`item.html.jinja2` inserted `link.url` straight into an `href` attribute with no
filter, while `link.title` on the same line was escaped. A URL containing a quote
character could therefore terminate the attribute early, so that the rest of the
value was parsed as further attributes on the anchor element. Attached link URLs
come from the Zotero library, so this is reachable by anyone who can add a link
attachment.

The fix applies `kerko_url_sanitize|escape`, matching what
`_search-result.html.jinja2` already does for the item URL.

## 2. `sync_index()` hides errors from `create_engine()`

`cache_engine` was assigned as the first statement of a `try` block whose
`finally` clause calls `cache_engine.dispose()`. If `create_engine()` itself
raised, the cleanup raised `UnboundLocalError: cannot access local variable
'cache_engine'` and the real error was lost. Moving the call ahead of the `try`
lets the original error through. Since `create_engine()` failures are not
`DatabaseError`, they were never caught by the `except` clause anyway, so the set
of exceptions a caller can see is unchanged.

## 3. En-dash page ranges are dropped from Highwire Press tags

`build_highwirepress_tags()` normalizes en-dashes to hyphens, then splits
`data["pages"]` — the original value — rather than the normalized one, so the
normalization is discarded. A page range of `5–7` produced:

| | before | after |
|---|---|---|
| `citation_firstpage` | `5–7` | `5` |
| `citation_lastpage` | *(absent)* | `7` |

Plain `5-7` was unaffected, which is presumably why this went unnoticed.

## 4. The "In {year}" facet label is unreachable

`YearTreeFacetCodec.decode()` compares `start` (a `str` from the path) with `end`
(an `int`), so the comparison is always false. A decade or century truncated to
the current year is labelled "Between 2020 and 2020" instead of "In 2020". This
shows up in the first year of any decade or century.

## 5. Search arguments leak between searches on a shared `Searcher`

`Searcher.search_args` is populated by `_prepare_search_args()` but never
cleared, and the individual `_prepare_*()` methods only assign the keys they
need. Anything left from a previous search on the same instance — `filter`,
`sortedby`, `reverse`, `groupedby`, `maptype` — silently carries into the next
one:

```
search #1  faceting=True, sort_spec, reject_any  -> ['filter','groupedby','maptype','reverse','sortedby']
search #2  faceting=False, no sort, no filters   -> ['filter','groupedby','maptype','reverse','sortedby']
```

No current view mixes modes on a shared instance, so I could not find a
user-visible symptom today — but `item_view()`, `inject_relations()` and
`empty_results()` all reuse one `Searcher` across several searches, so this is
one parameter change away from returning results filtered or sorted by criteria
the caller never asked for. Included as hardening; drop it if you would rather
not touch that code without a reproducer.

## A question rather than a change: `kerko.features.download_results`

`item_bib_download()` returns 404 when `kerko.features.download_item` is false,
but `search_bib_download()` does not make the equivalent check for
`kerko.features.download_results` — with the feature off, the button disappears
from the search page but `/export/<format>/` still serves the full bibliography.

I have deliberately *not* changed this, because `config-params.md` documents both
parameters as controlling a *button*, and describes `download_results_max_count`
as governing when the button is "hidden". So the current behaviour may well be
intended and `download_item`'s 404 may be the odd one out. Would you like the
check added for symmetry, or the documentation clarified instead? Happy to
follow up either way.

## Checks

- `python -m unittest`: 236 tests pass (219 before; 17 added).
- Each fix verified to fail its test when reverted individually.
- `pre-commit run --all-files` passes, including Ruff and mypy.
- Also run under Python 3.12 via `tox -e 3.12`; 3.11 and 3.13 were not available
  locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
